### PR TITLE
S390x support and Molecule 3

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+ignore = E501

--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -29,7 +29,7 @@ jobs:
         env:
           REDHAT_REGISTRY_SERVICE_ACCOUNT_USERNAME: ${{ secrets.REDHAT_REGISTRY_SERVICE_ACCOUNT_USERNAME }}
           REDHAT_REGISTRY_SERVICE_ACCOUNT_PASSWORD: ${{ secrets.REDHAT_REGISTRY_SERVICE_ACCOUNT_PASSWORD }}
+          RHEL80_ZSERIES_DEV: ${{ secrets.RHEL80_ZSERIES_DEV }}
 name: Molecule Test
 'on':
   - push
-  - pull_request

--- a/.yamllint
+++ b/.yamllint
@@ -1,3 +1,5 @@
+---
+# Based on ansible-lint config
 extends: default
 
 rules:
@@ -7,5 +9,25 @@ rules:
   brackets:
     max-spaces-inside: 1
     level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start: disable
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation: disable
+  key-duplicates: enable
   line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable
   truthy: disable

--- a/README.md
+++ b/README.md
@@ -58,6 +58,20 @@ Example Playbook
         golang_toolchain_sha: "001ac697f8f64d5d89625373a0ffa6aae13270a8"
 ```
 
+Testing
+-------
+
+Testing for this role in GitHub Actions and/or locally requires you to set up secrets and/or environment variables respectively.
+
+The required variables you need to set up are:
+1. `REDHAT_REGISTRY_SERVICE_ACCOUNT_USERNAME`
+2. `REDHAT_REGISTRY_SERVICE_ACCOUNT_PASSWORD`
+3. `RHEL80_ZSERIES_DEV`
+4. `PRIVATE_KEY`
+
+`RHEL80_ZSERIES_DEV` is formatted as username@host for the rhel80-zseries box
+`PRIVATE_KEY` is a private key that has access to the hosts
+
 License
 -------
 

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -21,17 +21,17 @@ def test_golang_toolchain(host):
 """
 
     cmd = host.run("GOROOT=/opt/golang/go1.9 /opt/golang/go1.9/bin/go version")
-    assert cmd.stdout ==  """go version go1.9.7 linux/amd64
+    assert cmd.stdout == """go version go1.9.7 linux/amd64
 """
 
     cmd = host.run("GOROOT=/opt/golang/go1.10 /opt/golang/go1.10/bin/go version")
-    assert cmd.stdout ==  """go version go1.10.8 linux/amd64
+    assert cmd.stdout == """go version go1.10.8 linux/amd64
 """
 
     cmd = host.run("GOROOT=/opt/golang/go1.11 /opt/golang/go1.11/bin/go version")
-    assert cmd.stdout ==  """go version go1.11.9 linux/amd64
+    assert cmd.stdout == """go version go1.11.9 linux/amd64
 """
 
     cmd = host.run("GOROOT=/opt/golang/go1.12 /opt/golang/go1.12/bin/go version")
-    assert cmd.stdout ==  """go version go1.12.8 linux/amd64
+    assert cmd.stdout == """go version go1.12.8 linux/amd64
 """

--- a/molecule/rhel80-zseries/INSTALL.rst
+++ b/molecule/rhel80-zseries/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ pip install 'molecule[docker]'

--- a/molecule/rhel80-zseries/converge.yml
+++ b/molecule/rhel80-zseries/converge.yml
@@ -1,0 +1,11 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: "Include ansible-role-golang-toolchain"
+      include_role:
+        name: "ansible-role-golang-toolchain"
+      vars:
+        golang_toolchain_url: https://ansible-molecule-test.s3.amazonaws.com/test_golangtoolchain.tar.gz
+        golang_toolchain_sha: testing_golang_sha
+        golang_toolchain_final_dest: /tmp/golang_test

--- a/molecule/rhel80-zseries/create.yml
+++ b/molecule/rhel80-zseries/create.yml
@@ -1,0 +1,9 @@
+---
+- gather_facts: false
+  name: Create
+  hosts: all
+  tasks:
+    - name: Create golang test directory
+      file:
+        path: /tmp/golang_test
+        state: directory

--- a/molecule/rhel80-zseries/destroy.yml
+++ b/molecule/rhel80-zseries/destroy.yml
@@ -1,0 +1,9 @@
+---
+- gather_facts: false
+  name: Destroy
+  hosts: all
+  tasks:
+    - name: Delete golang test directory
+      file:
+        path: /tmp/golang_test
+        state: absent

--- a/molecule/rhel80-zseries/molecule.yml
+++ b/molecule/rhel80-zseries/molecule.yml
@@ -1,0 +1,17 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: delegated
+  identity_file: ~/.ssh/id_rsa
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+  flake8
+platforms:
+  - name: ${RHEL80_ZSERIES_DEV}
+provisioner:
+  name: ansible
+verifier:
+  name: testinfra

--- a/molecule/rhel80-zseries/requirements.yml
+++ b/molecule/rhel80-zseries/requirements.yml
@@ -1,0 +1,3 @@
+---
+- name: ansible-role-toolchain
+  src: git+https://github.com/mongodb-ansible-roles/ansible-role-toolchain.git

--- a/molecule/rhel80-zseries/tests/test_default.py
+++ b/molecule/rhel80-zseries/tests/test_default.py
@@ -1,0 +1,37 @@
+import os
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']
+).get_hosts('all')
+
+
+def test_golang_toolchain(host):
+    assert host.file("/tmp/golang_test").exists
+    assert host.file("/tmp/golang_test/toolchain_version").exists
+    assert host.file("/tmp/golang_test/toolchain_version").contains("testing_golang_sha")
+
+    cmd = host.run("GOROOT=/tmp/golang_test/go1.7 /tmp/golang_test/go1.7/bin/go version")
+    assert cmd.stdout == """go version go1.7.6 linux/amd64
+"""
+
+    cmd = host.run("GOROOT=/tmp/golang_test/go1.8 /tmp/golang_test/go1.8/bin/go version")
+    assert cmd.stdout == """go version go1.8.7 linux/amd64
+"""
+
+    cmd = host.run("GOROOT=/tmp/golang_test/go1.9 /tmp/golang_test/go1.9/bin/go version")
+    assert cmd.stdout == """go version go1.9.7 linux/amd64
+"""
+
+    cmd = host.run("GOROOT=/tmp/golang_test/go1.10 /tmp/golang_test/go1.10/bin/go version")
+    assert cmd.stdout == """go version go1.10.8 linux/amd64
+"""
+
+    cmd = host.run("GOROOT=/tmp/golang_test/go1.11 /tmp/golang_test/go1.11/bin/go version")
+    assert cmd.stdout == """go version go1.11.9 linux/amd64
+"""
+
+    cmd = host.run("GOROOT=/tmp/golang_test/go1.12 /tmp/golang_test/go1.12/bin/go version")
+    assert cmd.stdout == """go version go1.12.8 linux/amd64
+"""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,14 +7,15 @@
   when:
     - toolchain_archive_contents.changed
 
-- name: Move golang directory from tmp to opt
+- name: Move golang directory from tmp to {{ golang_toolchain_final_dest }}
   become: true
   command: mv /tmp/golang {{ golang_toolchain_final_dest }}
   when:
     - toolchain_archive_contents.changed
 
-- name: Create version file
+  # This is using shell because the copy and template module fail to run on a static host
+  # with a "host cannot be found error"
+- name: Create version file at {{ golang_toolchain_final_dest }}/toolchain_version
   become: true
-  copy:
-    content: "{{ golang_toolchain_sha }}"
-    dest: "{{ golang_toolchain_final_dest }}/toolchain_version"
+  shell: echo {{ golang_toolchain_sha }} > {{ golang_toolchain_final_dest }}/toolchain_version
+  changed_when: false

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -8,4 +8,5 @@ distro: "{{ distro_dict[ansible_os_family] }}"
 architecture_dict:
   x86_64: amd64
   ppc64le: ppc64le
+  s390x: s390x
 architecture: "{{ architecture_dict[ansible_architecture] }}"


### PR DESCRIPTION
### Description

This PR adds s390x support, with a rhel80-zseries box to test on.

There is an issue with both the copy and template module where it fails with a `cannot find host` error. Using a shell script to echo the version into a file does work however.

This PR also upgrades molecule to v3 and makes changes to make old tests compatible. The default test suite will still be testinfra, instead of ansible.

Also removes the test run on PR, because it still runs on push.